### PR TITLE
Add sprintGoals.md

### DIFF
--- a/sprintGoals.md
+++ b/sprintGoals.md
@@ -1,0 +1,32 @@
+# Sprint goals
+
+The goals for each sprint may be published here below for everyone to see.
+
+## Sprint 1
+
+2023-09-11 – 2023-09-15
+
+| Goal for BMS | Link to issue |
+| --- | --- |
+| Decide which MCU to use | [issue](https://github.com/AlexTelon/FlexiCharge-BMS/issues/23) |
+| Research and choose git workflow | [issue](https://github.com/AlexTelon/FlexiCharge-BMS/issues/22) |
+| Set up software development environment | [issue](https://github.com/AlexTelon/FlexiCharge-BMS/issues/12) |
+| Create MCU Hello World / Blinky | [issue](https://github.com/AlexTelon/FlexiCharge-BMS/issues/24) |
+| Read battery cell voltage | [issue](https://github.com/AlexTelon/FlexiCharge-BMS/issues/25) |
+| Discuss communication protocol with charger squad | [issue](https://github.com/AlexTelon/FlexiCharge-BMS/issues/26) |
+
+&nbsp; <!-- spacing -->
+
+| Goal for other squad... | Link to issue |
+| --- | --- |
+| Goal #1 | issue |
+| Goal #2 | issue |
+| Goal #3 | issue |
+
+&nbsp; <!-- spacing -->
+
+| Goal for other squad... | Link to issue |
+| --- | --- |
+| Goal #1 | issue |
+| Goal #2 | issue |
+| Goal #3 | issue |


### PR DESCRIPTION
Meant for publishing the sprint goals for each squad each sprint. This is due to a request that sprint backlogs should be uploaded to the FlexiCharge-Org repository.